### PR TITLE
fix: replace non-existent anchore actions with curl-based installs

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -121,9 +121,8 @@ jobs:
           cache-to: type=gha,mode=max
 
       # ── Scanning ─────────────────────────────────────────────────
-      # Install Grype using the dedicated setup action (replaces scan-action/setup)
       - name: Install Grype
-        uses: anchore/setup-grype@v1
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
       # Run Grype once and write both SARIF (for GitHub Security tab) and JSON
       # (for policy evaluation).  We do NOT pass --fail-on here — the policy gate
@@ -155,9 +154,8 @@ jobs:
             --config images/${{ matrix.image }}/test/structure.yaml
 
       # ── SBOM Generation ──────────────────────────────────────────
-      # Install Syft using the dedicated setup action (replaces sbom-action/setup)
       - name: Install Syft
-        uses: anchore/setup-syft@v2
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Generate SBOM
         run: |

--- a/.github/workflows/scheduled-scan.yaml
+++ b/.github/workflows/scheduled-scan.yaml
@@ -58,7 +58,7 @@ jobs:
 
       # ── Grype Scan ──────────────────────────────────────────────
       - name: Install Grype
-        uses: anchore/scan-action/setup@v3
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Scan with Grype
         id: grype


### PR DESCRIPTION
## Summary

- `anchore/setup-grype@v1`, `anchore/setup-syft@v2`, and `anchore/scan-action/setup@v3` do not exist as GitHub Actions repositories — confirmed 404 on all three
- This caused every `build` job to fail at **Set up job** (GitHub cannot resolve the action reference before any steps run)
- Fix: replace with official Grype/Syft curl install scripts, which is the recommended method for CI environments

## Test plan

- [ ] CI run on this PR should show all `build` jobs advancing past "Set up job"
- [ ] `detect-changes`, `validate`, and all `build (*)` jobs should complete without "Set up job" failures
- [ ] Grype scan, container-structure-tests, and Syft SBOM generation should run as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)