### PR TITLE
fix: run set-nonroot.sh before strip-shells.sh in all Dockerfiles

### DIFF
--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -20,8 +20,8 @@ COPY shared/hardening/set-nonroot.sh /tmp/
 RUN apk add --no-cache bash && \
     chmod +x /tmp/*.sh && \
     /tmp/minimize-packages.sh && \
-    /tmp/strip-shells.sh && \
     /tmp/set-nonroot.sh && \
+    /tmp/strip-shells.sh && \
     rm -rf /tmp/*.sh
 
 # Alpine-specific hardening

--- a/images/debian-slim/Dockerfile
+++ b/images/debian-slim/Dockerfile
@@ -24,10 +24,10 @@ RUN apt-get update && \
 
 RUN chmod +x /tmp/*.sh && \
     /tmp/minimize-packages.sh && \
+    /tmp/set-nonroot.sh && \
     /tmp/strip-shells.sh && \
     # Purge bash from the apt database so future apt runs can't reinstate it
     apt-get purge -y bash > /dev/null 2>&1 || true && \
-    /tmp/set-nonroot.sh && \
     rm -rf /tmp/*.sh /var/lib/apt/lists/* /var/cache/apt/*
 
 # Debian-specific hardening

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -20,8 +20,8 @@ COPY shared/hardening/set-nonroot.sh /tmp/
 RUN apk add --no-cache bash && \
     chmod +x /tmp/*.sh && \
     /tmp/minimize-packages.sh && \
-    /tmp/strip-shells.sh && \
     /tmp/set-nonroot.sh && \
+    /tmp/strip-shells.sh && \
     rm -rf /tmp/*.sh
 
 # Configure nginx to run as non-root

--- a/images/node/20/Dockerfile
+++ b/images/node/20/Dockerfile
@@ -17,8 +17,8 @@ COPY shared/hardening/set-nonroot.sh /tmp/
 
 RUN chmod +x /tmp/*.sh && \
     /tmp/minimize-packages.sh && \
-    /tmp/strip-shells.sh && \
     /tmp/set-nonroot.sh && \
+    /tmp/strip-shells.sh && \
     rm -rf /tmp/*.sh /var/lib/apt/lists/* /var/cache/apt/*
 
 # Remove npm cache and unnecessary node tooling

--- a/images/python/3.12/Dockerfile
+++ b/images/python/3.12/Dockerfile
@@ -17,8 +17,8 @@ COPY shared/hardening/set-nonroot.sh /tmp/
 
 RUN chmod +x /tmp/*.sh && \
     /tmp/minimize-packages.sh && \
-    /tmp/strip-shells.sh && \
     /tmp/set-nonroot.sh && \
+    /tmp/strip-shells.sh && \
     rm -rf /tmp/*.sh /var/lib/apt/lists/* /var/cache/apt/*
 
 # Remove pip cache and bytecode to reduce image size


### PR DESCRIPTION
## Root cause

`set-nonroot.sh` has a `#!/usr/bin/env bash` shebang. `strip-shells.sh` removes `/bin/bash` (and `/usr/bin/bash`, which is the same inode on Debian). All 5 Dockerfiles ran scripts in this order:

```
minimize-packages.sh → strip-shells.sh → set-nonroot.sh
```

Once `strip-shells.sh` finishes, `env` cannot find `bash`, so `set-nonroot.sh` fails immediately — aborting the `RUN` layer and the build.

## Fix

Swap the order so `set-nonroot.sh` runs while bash is still present:

```
minimize-packages.sh → set-nonroot.sh → strip-shells.sh
```

Applied to all 5 images: `python/3.12`, `node/20`, `debian-slim`, `alpine`, `nginx`.

## Test plan
- [ ] Build workflow passes for all 5 images in CI
- [ ] `nonroot` user (UID 65532) present in built images
- [ ] `/bin/bash` absent from built images (confirmed by structure tests)