### PR TITLE
ci: narrow build matrix to python/3.12 only

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -49,11 +49,8 @@ jobs:
             # Manual trigger for a specific image
             echo 'matrix={"image":["${{ github.event.inputs.image }}"]}' >> "$GITHUB_OUTPUT"
           else
-            # Build all images
-            IMAGES=$(find images -name Dockerfile -exec dirname {} \; \
-              | sed 's|^images/||' \
-              | jq -R -s -c 'split("\n") | map(select(length > 0))')
-            echo "matrix={\"image\":$IMAGES}" >> "$GITHUB_OUTPUT"
+            # Focus on python/3.12 first; enable remaining images once this one is green
+            echo 'matrix={"image":["python/3.12"]}' >> "$GITHUB_OUTPUT"
           fi
 
   # Validate images.yaml with CascadeGuard — dogfooding our own tool.


### PR DESCRIPTION
## Summary

- Narrows CI build matrix to python/3.12 only per CTO directive
- Get one image building green end-to-end before enabling the full matrix
- Other images can still be built via workflow_dispatch input

## Context

PR #4 (merged) fixed the /tmp deletion and script ordering bugs. Now focusing on validating the full pipeline with a single image before scaling back out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)