### PR TITLE
fix: preserve /bin/sh backing binary and fix apt cascading removal

### DIFF
--- a/shared/hardening/minimize-packages.sh
+++ b/shared/hardening/minimize-packages.sh
@@ -54,20 +54,23 @@ if is_debian; then
     gpg-agent
     apt-utils
     e2fsprogs
-    fdisk
-    mount
-    util-linux
   )
 
   echo "  Removing unnecessary Debian packages..."
+  # Collect actually-installed packages first, then remove in a single pass
+  # to avoid cascading auto-remove side-effects that break subsequent scripts.
+  INSTALLED=()
   for pkg in "${PACKAGES_TO_REMOVE[@]}"; do
-    if dpkg -l "$pkg" > /dev/null 2>&1; then
-      apt-get purge -y --auto-remove "$pkg" > /dev/null 2>&1 || true
+    if dpkg -l "$pkg" 2>/dev/null | grep -q '^ii'; then
+      INSTALLED+=("$pkg")
     fi
   done
+  if [ ${#INSTALLED[@]} -gt 0 ]; then
+    apt-get purge -y "${INSTALLED[@]}" > /dev/null 2>&1 || true
+  fi
 
-  # Aggressive autoremove and clean
-  apt-get autoremove -y --purge > /dev/null 2>&1 || true
+  # Light autoremove (no --purge to avoid cascading into essential deps)
+  apt-get autoremove -y > /dev/null 2>&1 || true
   apt-get clean
   rm -rf /var/lib/apt/lists/*
   rm -rf /var/cache/apt/*

--- a/shared/hardening/strip-shells.sh
+++ b/shared/hardening/strip-shells.sh
@@ -12,7 +12,15 @@ set -euo pipefail
 
 echo "[cascadeguard] Stripping unnecessary shell binaries..."
 
-# Shells to remove — we preserve /bin/sh (required for RUN directives during build)
+# Shells to remove — we preserve /bin/sh (required for RUN directives during build).
+# On Debian, /bin/sh is a symlink to /bin/dash, so we must not remove the shell
+# binary that /bin/sh resolves to — otherwise subsequent Dockerfile RUN instructions
+# would fail with "no such file or directory".
+SH_TARGET=""
+if [ -L /bin/sh ]; then
+  SH_TARGET=$(readlink -f /bin/sh)
+fi
+
 SHELLS_TO_REMOVE=(
   /bin/bash
   /bin/dash
@@ -31,6 +39,12 @@ SHELLS_TO_REMOVE=(
 removed=0
 for shell in "${SHELLS_TO_REMOVE[@]}"; do
   if [ -f "$shell" ] || [ -L "$shell" ]; then
+    # Skip if this is the binary backing /bin/sh
+    real=$(readlink -f "$shell" 2>/dev/null || echo "$shell")
+    if [ "$real" = "$SH_TARGET" ]; then
+      echo "  Kept: $shell (backs /bin/sh)"
+      continue
+    fi
     rm -f "$shell"
     echo "  Removed: $shell"
     removed=$((removed + 1))


### PR DESCRIPTION
## Summary

- **Root cause 1:** `strip-shells.sh` removed `/bin/dash`, but on Debian `/bin/sh` is a symlink to `/bin/dash`. This broke all subsequent Dockerfile `RUN` instructions.
- **Root cause 2:** `minimize-packages.sh` ran `apt-get purge --auto-remove` per-package, cascading into removing essential dependencies.

## Changes

- `strip-shells.sh`: Detect which binary `/bin/sh` resolves to and skip removing it
- `minimize-packages.sh`: Batch purge without `--auto-remove`, lighter `autoremove`, removed util-linux/fdisk/mount from removal list

## Test plan

- [ ] CI build passes for python/3.12 (currently the only image in matrix)
- [ ] Structure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)