### PR TITLE
fix(CAS-419): skip images without dockerfile field in CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,9 @@ jobs:
 
           filter_name = os.environ.get('IMAGE_FILTER', '').strip()
 
+          active = [img for img in images if img.get('enabled', True) is not False]
           include = []
-          for img in images:
+          for img in active:
               # Derive image_path from dockerfile path:
               # "images/python/3.12/Dockerfile" -> "python/3.12"
               parts = img['dockerfile'].split('/')


### PR DESCRIPTION
## Summary

The CI pipeline in `cascadeguard-open-secure-images` has been broken since April 4 when `images.yaml` was unified to include upstream-tracked images ([CAS-411]).

**Problem:** `ci.yaml` matrix generation iterated all entries in `images.yaml` and accessed `img["dockerfile"]` without guarding for upstream-tracked images with `enabled: false` that lack this field. The Python script crashed with `KeyError: "dockerfile"`, so no images were built or pushed.

**Fix:** Added the same `enabled` filter already present in `scheduled-scan.yaml`:
```python
active = [img for img in images if img.get("enabled", True) is not False]
```

Only active images are included in the build matrix.

Closes CAS-419