### PR TITLE
fix: skip images without dockerfile in CI matrix generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,8 @@ jobs:
           active = [img for img in images if img.get('enabled', True) is not False]
           include = []
           for img in active:
+              if 'dockerfile' not in img:
+                  continue
               # Derive image_path from dockerfile path:
               # "images/python/3.12/Dockerfile" -> "python/3.12"
               parts = img['dockerfile'].split('/')


### PR DESCRIPTION
Entries without a `dockerfile` field (upstream-tracked images) are now skipped in the CI build matrix. Previously this caused a `KeyError: 'dockerfile'` crash when images.yaml contained check-only entries.