### PR TITLE
fix: add permissions block to build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,13 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  security-events: write
+  attestations: write
+
 jobs:
   build:
     uses: cascadeguard/cascadeguard-actions/.github/workflows/build.yaml@main


### PR DESCRIPTION
The reusable build workflow in cascadeguard-actions requires elevated permissions. Callers must declare `attestations:write`, `packages:write`, `security-events:write`, and `id-token:write`.