### PR TITLE
chore: bump CLI to a028744 (CAS-564) and pin cascadeguard-actions SHA

### DIFF
--- a/.cascadeguard.yaml
+++ b/.cascadeguard.yaml
@@ -1,0 +1,6 @@
+# CascadeGuard configuration
+# See https://docs.cascadeguard.com/configuration
+
+cli:
+  # Pin to feat(CAS-564): multi-registry OCI tag fetching for ghcr.io and quay.io.
+  version: "a028744c4cf1733c5c1d5df725260f285eb1698c"

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     with:
       image_path: ${{ inputs.image_path }}
       image_name: ${{ inputs.image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Generate build matrix
         id: gen
-        uses: cascadeguard/cascadeguard-actions/generate-build-matrix@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+        uses: cascadeguard/cascadeguard-actions/generate-build-matrix@510b0009b78df3114345cb907db6b026da79d7ab # main
         with:
           image-filter: ${{ github.event.inputs.image_filter || '' }}
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+      - uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@510b0009b78df3114345cb907db6b026da79d7ab # main
       - run: cascadeguard images validate
 
   # ── Per-Image Build ──────────────────────────────────────────────
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     with:
       image_path: ${{ matrix.image_path }}
       image_name: ${{ matrix.image_name }}
@@ -71,7 +71,7 @@ jobs:
 
   # ── Actions Policy ───────────────────────────────────────────────
   policy:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
 
   # ── Build Gate ───────────────────────────────────────────────────
   build-gate:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,5 +22,5 @@ permissions:
 
 jobs:
   check:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/check.yaml@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/check.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     secrets: inherit

--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   audit:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     with:
       policy_path: ${{ inputs.policy_path }}
       workflows_dir: ${{ inputs.workflows_dir }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up CascadeGuard CLI
-        uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+        uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@510b0009b78df3114345cb907db6b026da79d7ab # main
       - name: CascadeGuard validate
         run: cascadeguard images validate
 
   # ── Actions Policy Enforcement ───────────────────────────────────
   policy:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@a2c4597db798af7e37b9cf01d14e786860f55b85 # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main

--- a/.github/workflows/pr-path-guard.yaml
+++ b/.github/workflows/pr-path-guard.yaml
@@ -6,7 +6,7 @@
 # Uses the shared block-sensitive-paths action from cascadeguard-actions.
 # Other CascadeGuard public repos can reuse it with:
 #
-#   uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@main
+#   uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@510b0009b78df3114345cb907db6b026da79d7ab # main
 
 name: PR Path Guard
 
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Block sensitive paths
-        uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@main
+        uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@510b0009b78df3114345cb907db6b026da79d7ab # main
         with:
           blocked-paths: |
             .ai/

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Resolve image from images.yaml
         id: resolve
-        uses: cascadeguard/cascadeguard-actions/resolve-image@main
+        uses: cascadeguard/cascadeguard-actions/resolve-image@510b0009b78df3114345cb907db6b026da79d7ab # main
         with:
           image-name: ${{ github.event.client_payload.image_name }}
           image-tag: ${{ github.event.client_payload.image_tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/release.yaml@main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/release.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
     with:
       image-prefix-ghcr: ghcr.io/${{ github.repository_owner }}
       image-prefix-dockerhub: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

Bump CascadeGuard CLI to post-CAS-564 merge SHA `a028744c` which added:
- Multi-registry OCI tag fetching (ghcr.io, quay.io)
- `skip_tag_fetch` for unsupported registries

Changes:
- Add `.cascadeguard.yaml` with `cli.version: a028744c`
- Pin all `cascadeguard-actions` workflow refs from `@main` to `510b0009` (current main SHA)

Refs: CAS-578, CAS-564

## Test plan
- [ ] CI passes on this PR