### PR TITLE
ci(CAS-614): add check-dry-run job to PR Check workflow

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -28,3 +28,8 @@ jobs:
   # ── Actions Policy Enforcement ───────────────────────────────────
   policy:
     uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+
+  # ── Dry-Run Check ────────────────────────────────────────────────
+  dry-run:
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/check-dry-run.yaml@eec3d4c801942e68667e9f84cecd7b0a195f8cee # main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the `dry-run` job to the PR Check workflow, calling the new reusable `check-dry-run.yaml` from cascadeguard-actions
- Surfaces image drift on every PR without touching state (read-only, no commits/PRs opened)
- Pinned to `eec3d4c` (the merged CAS-614 commit on cascadeguard-actions main)

Part of CAS-614 rollout.