### PR TITLE
chore: dependabot sweep 2026-05 (cascadeguard-actions hash bumps)

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
     with:
       image_path: ${{ inputs.image_path }}
       image_name: ${{ inputs.image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Generate build matrix
         id: gen
-        uses: cascadeguard/cascadeguard-actions/generate-build-matrix@510b0009b78df3114345cb907db6b026da79d7ab # main
+        uses: cascadeguard/cascadeguard-actions/generate-build-matrix@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
         with:
           image-filter: ${{ github.event.inputs.image_filter || '' }}
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@510b0009b78df3114345cb907db6b026da79d7ab # main
+      - uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
       - run: cascadeguard images validate
 
   # ── Per-Image Build ──────────────────────────────────────────────

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
 
   # ── Actions Policy ───────────────────────────────────────────────
   policy:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
 
   # ── Build Gate ───────────────────────────────────────────────────
   build-gate:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/build-image.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
     with:
       image_path: ${{ matrix.image_path }}
       image_name: ${{ matrix.image_name }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,5 +22,5 @@ permissions:
 
 jobs:
   check:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/check.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/check.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
     secrets: inherit

--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   audit:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
     with:
       policy_path: ${{ inputs.policy_path }}
       workflows_dir: ${{ inputs.workflows_dir }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up CascadeGuard CLI
-        uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@510b0009b78df3114345cb907db6b026da79d7ab # main
+        uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
       - name: CascadeGuard validate
         run: cascadeguard images validate
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,7 +27,7 @@ jobs:
 
   # ── Actions Policy Enforcement ───────────────────────────────────
   policy:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@510b0009b78df3114345cb907db6b026da79d7ab # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/enforce-actions-policy.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
 
   # ── Dry-Run Check ────────────────────────────────────────────────
   dry-run:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -31,5 +31,5 @@ jobs:
 
   # ── Dry-Run Check ────────────────────────────────────────────────
   dry-run:
-    uses: cascadeguard/cascadeguard-actions/.github/workflows/check-dry-run.yaml@eec3d4c801942e68667e9f84cecd7b0a195f8cee # main
+    uses: cascadeguard/cascadeguard-actions/.github/workflows/check-dry-run.yaml@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
     secrets: inherit

--- a/.github/workflows/pr-path-guard.yaml
+++ b/.github/workflows/pr-path-guard.yaml
@@ -6,7 +6,7 @@
 # Uses the shared block-sensitive-paths action from cascadeguard-actions.
 # Other CascadeGuard public repos can reuse it with:
 #
-#   uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@510b0009b78df3114345cb907db6b026da79d7ab # main
+#   uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
 
 name: PR Path Guard
 
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Block sensitive paths
-        uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@510b0009b78df3114345cb907db6b026da79d7ab # main
+        uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
         with:
           blocked-paths: |
             .ai/

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Resolve image from images.yaml
         id: resolve
-        uses: cascadeguard/cascadeguard-actions/resolve-image@510b0009b78df3114345cb907db6b026da79d7ab # main
+        uses: cascadeguard/cascadeguard-actions/resolve-image@23b32fea1e1f1992faea9e978e9741810bf3ebac # main
         with:
           image-name: ${{ github.event.client_payload.image_name }}
           image-tag: ${{ github.event.client_payload.image_tag }}


### PR DESCRIPTION
## Dependabot Sweep — May 2026

Rolls up all cascadeguard-actions SHA hash bumps (510b000 → 23b32fea) across all workflow files.

### Included
- `cascadeguard-actions` root ref (#89)
- `cascadeguard-actions/build-image.yaml` (#88)
- `cascadeguard-actions/check.yaml` (#91)
- `cascadeguard-actions/check-dry-run.yaml` (#92)
- `cascadeguard-actions/enforce-actions-policy.yaml` (#90)

Part of routine [CAS-695](/CAS/issues/CAS-695) weekly Dependabot sweep.